### PR TITLE
chore: bump snyk expiration for unpatchable vulns

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,13 +5,9 @@ ignore:
   SNYK-JAVA-LOG4J-572732:
     - '*':
         reason: no available replacement
-        expires: 2020-10-31T00:00:00.000Z
+        expires: 2020-12-31T00:00:00.000Z
   SNYK-JAVA-IONETTY-473694:
     - '*':
         reason: no available replacement
-        expires: 2020-10-31T00:00:00.000Z
-  SNYK-JAVA-IOGRPC-571957:
-    - '*':
-        reason: No replacement available
-        expires: 2020-10-31T00:00:00.000Z
+        expires: 2020-12-31T00:00:00.000Z
 patch: {}

--- a/hypertrace-service/build.gradle.kts
+++ b/hypertrace-service/build.gradle.kts
@@ -9,14 +9,6 @@ plugins {
 
 var hypertraceUiVersion = "latest"
 
-configurations {
-  "implementation" {
-    resolutionStrategy {
-      force("io.grpc:grpc-netty:1.33.0")
-    }
-  }
-}
-
 dependencies {
   implementation("org.hypertrace.core.attribute.service:attribute-service")
   implementation("org.hypertrace.core.attribute.service:attribute-service-impl")
@@ -48,6 +40,12 @@ dependencies {
 
   // Config
   implementation("com.typesafe:config:1.4.0")
+
+  constraints {
+    implementation("com.google.guava:guava:30.0-jre") {
+      because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")
+    }
+  }
 }
 
 application {


### PR DESCRIPTION
## Description
Updated snyk expirations on vulnerabilities without available fixes. Removed vulnerability ignores for things we've since updated.

### Testing
Ran snyk locally
