### PR TITLE
Avoids running CI build on markdown or text file changes

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
   pull_request:
   # workflow_dispatch will let us manually trigger the workflow from GitHub actions dashboard.
   # See https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow 


### PR DESCRIPTION
## Description
Earlier we were running CI on every single change including changes in README file which is not necessary at all. 

As @adriancole suggested GitHub actions supports path filters which we can use to avoid running CI on changes in markdown or text files. 

This PR adds path filters in GitHub action based CI running in this repo. 

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Tested with changes in GH action. 

### Checklist:
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules

### Documentation

References for this PR:
- https://github.community/t/using-on-push-tags-ignore-and-paths-ignore-together/16931
- https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
