### PR TITLE
fix pinot health check configuration

### DIFF
--- a/hypertrace-service/src/main/java/org/hypertrace/service/HypertraceUIServerTimerTask.java
+++ b/hypertrace-service/src/main/java/org/hypertrace/service/HypertraceUIServerTimerTask.java
@@ -35,10 +35,8 @@ public class HypertraceUIServerTimerTask extends TimerTask {
   private static final int DEFAULT_INTERVAL = 5;
   private static final String START_PERIOD = "hypertraceUI.init.waittime.start_period";
   private static final int DEFAULT_START_PERIOD = 20;
-  private static final String PINOT_SERVER_HOST = "pinot.server_host";
-  private static final String DEFAULT_PINOT_SERVER_HOST = "pinot-controller";
-  private static final String PINOT_SERVER_PORT = "pinot.server_port";
-  private static final int DEFAULT_PINOT_SERVER_PORT = 8097;
+  private static final String PINOT_CONTROLLER_HOST = "pinot.controller_host";
+  private static final String DEFAULT_PINOT_CONTROLLER_HOST = "pinot-controller";
   private static final String PINOT_CONTROLLER_PORT = "pinot.controller_port";
   private static final int DEFAULT_PINOT_CONTROLLER_PORT = 9000;
 
@@ -51,8 +49,7 @@ public class HypertraceUIServerTimerTask extends TimerTask {
   private long interval;
   private long startPeriod;
   private String defaultTenant;
-  private String pinotSeverHost;
-  private int pinotServerPort;
+  private String pinotControllerHost;
   private int pinotControllerPort;
   private boolean isPinotUp;
 
@@ -67,10 +64,8 @@ public class HypertraceUIServerTimerTask extends TimerTask {
     startPeriod =
         appConfig.hasPath(START_PERIOD) ? appConfig.getInt(START_PERIOD) : DEFAULT_START_PERIOD;
 
-    pinotSeverHost = appConfig.hasPath(PINOT_SERVER_HOST) ?
-        appConfig.getString(PINOT_SERVER_HOST) : DEFAULT_PINOT_SERVER_HOST;
-    pinotServerPort = appConfig.hasPath(PINOT_SERVER_PORT) ?
-        appConfig.getInt(PINOT_SERVER_PORT) : DEFAULT_PINOT_SERVER_PORT;
+    pinotControllerHost = appConfig.hasPath(PINOT_CONTROLLER_HOST) ?
+        appConfig.getString(PINOT_CONTROLLER_HOST) : DEFAULT_PINOT_CONTROLLER_HOST;
     pinotControllerPort = appConfig.hasPath(PINOT_CONTROLLER_PORT) ?
         appConfig.getInt(PINOT_CONTROLLER_PORT) : DEFAULT_PINOT_CONTROLLER_PORT;
 
@@ -168,7 +163,7 @@ public class HypertraceUIServerTimerTask extends TimerTask {
   private boolean executePinotHealthCheck() throws Exception {
     HttpURLConnection con = null;
     try {
-      URL url = new URL(String.format("http://%s:%s/health", pinotSeverHost, pinotServerPort));
+      URL url = new URL(String.format("http://%s:%s/health", pinotControllerHost, pinotControllerPort));
       con = (HttpURLConnection) url.openConnection();
       con.setRequestMethod("GET");
       con.setConnectTimeout(timeout * 1000);
@@ -188,7 +183,7 @@ public class HypertraceUIServerTimerTask extends TimerTask {
     HttpURLConnection con = null;
     try {
       URL url = new URL(
-          String.format("http://%s:%s/brokers/tenants", pinotSeverHost, pinotControllerPort));
+          String.format("http://%s:%s/brokers/tenants", pinotControllerHost, pinotControllerPort));
       con = (HttpURLConnection) url.openConnection();
       con.setRequestMethod("GET");
       con.setConnectTimeout(timeout * 1000);

--- a/hypertrace-service/src/main/resources/configs/hypertrace-service/application.conf
+++ b/hypertrace-service/src/main/resources/configs/hypertrace-service/application.conf
@@ -25,10 +25,8 @@ hypertraceUI {
   }
 }
 pinot {
-  server_host = "pinot-controller"
-  server_host = ${?PINOT_SERVER_HOST}
-  server_port = 8097
-  server_port = ${?PINOT_SERVER_PORT}
+  controller_host = "pinot-controller"
+  controller_host = ${?PINOT_CONTROLLER_HOST}
   controller_port = 9000
   controller_port = ${?PINOT_CONTROLLER_PORT}
 }


### PR DESCRIPTION
## Description
Pinot 0.6.0 controllers now have a health check: https://github.com/apache/incubator-pinot/pull/5846
So we should just use that instead of confusing people with asking about a single pinot server health check, and making
it impossible to reference a controller running on a different host.

### Checklist:
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
As far as I can tell this configuration isn't referenced anywhere, but perhaps I am blind.

For reference a Pinot Server: https://docs.pinot.apache.org/developers/advanced/advanced-pinot-setup#pinot-server
And Pinot Controller: https://docs.pinot.apache.org/developers/advanced/advanced-pinot-setup#pinot-controller
Are two different components of this distributed system. This service only relies on the Controller `/brokers/tenants` [API](https://github.com/hypertrace/hypertrace-service/blob/main/hypertrace-service/src/main/java/org/hypertrace/service/HypertraceUIServerTimerTask.java#L191) and yet it was using the Server's `/health` API in the absence of a `/health` endpoint on the controller itself.