### PR TITLE
chore: ensures users not in our org avoid authentication problems

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
 [submodule "attribute-service"]
 	path = attribute-service
-	url = git@github.com:hypertrace/attribute-service.git
+	url = https://github.com/hypertrace/attribute-service.git
 	branch = main
 [submodule "entity-service"]
 	path = entity-service
-	url = git@github.com:hypertrace/entity-service.git
+	url = https://github.com/hypertrace/entity-service.git
 	branch = main
 [submodule "gateway-service"]
 	path = gateway-service
@@ -20,7 +20,7 @@
 	branch = main
 [submodule "config-bootstrapper"]
 	path = config-bootstrapper
-	url = git@github.com:hypertrace/config-bootstrapper.git
+	url = https://github.com/hypertrace/config-bootstrapper.git
 	branch = main
 [submodule "config-service"]
   path = config-service


### PR DESCRIPTION
## Description
If we use git/SSH URLs then non-members face authentication issues while cloning the repo. Some recent changes added git URLs so replacing it with https to avoid these kind of issues. 

### Testing
NA

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
- https://github.com/hypertrace/hypertrace-service/pull/10 
