### PR TITLE
chore: for ease of debugging, adds options for java opts

### DIFF
--- a/hypertrace-service/Dockerfile
+++ b/hypertrace-service/Dockerfile
@@ -8,7 +8,8 @@ COPY build/docker/libs libs/
 COPY build/docker/resources resources/
 COPY build/docker/classes classes/
 COPY --from=ui /usr/share/nginx/html resources/hypertrace-ui
-ENTRYPOINT ["java", "-cp", "/app/resources:/app/classes:/app/libs/*", "org.hypertrace.core.serviceframework.PlatformServiceLauncher"]
+COPY docker_entrypoint.sh docker_entrypoint.sh
+ENTRYPOINT ["/app/docker_entrypoint.sh"]
 EXPOSE 9001 9002 2020
 HEALTHCHECK --interval=2s --start-period=15s --timeout=2s CMD wget -qO- http://127.0.0.1:9002/health &> /dev/null || exit 1
-ENV SERVICE_NAME=hypertrace-service
+ENV SERVICE_NAME=hypertrace-service JAVA_OPTS=""

--- a/hypertrace-service/docker_entrypoint.sh
+++ b/hypertrace-service/docker_entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+exec java $JAVA_OPTS -classpath '/app/resources:/app/classes:/app/libs/*' org.hypertrace.core.serviceframework.PlatformServiceLauncher


### PR DESCRIPTION
## Description
For ease of debugging, this PR adds JAVA_OPTS environment for hypertrace-service. With these changes, now, we will able to debug from intellij using remote configuration.

Steps:
1. Build the docker image locally if you have made any changes using gradle command
```gradlew dockerBuildImages```
2. Modify the docker-compose file as shown below by adding JAVA_OPTS and exposing 5005 debug port
```
hypertrace:
    image: traceableai-docker.jfrog.io/hypertrace/hypertrace:test
    environment:
      - DATA_STORE_TYPE=postgres
      - POSTGRES_HOST=postgres
      - ZK_CONNECT_STR=zookeeper:2181/hypertrace-views
      - JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
    ports:
      - 2020:2020
      - 5005:5005
    healthcheck:
      start_period: 20s
    depends_on:
      postgres:
        condition: service_started
      kafka-zookeeper:
        condition: service_healthy
      pinot:
        condition: service_started
```
3. User remote configuration of Intellij for attaching a debugger
<img width="1302" alt="remote-config" src="https://user-images.githubusercontent.com/53209990/121527186-c5694080-ca17-11eb-9ff4-c7734cdce311.png">


### Testing
Verified locally with docker-compose.
