### PR TITLE
chore: upgrade gradle version to fix intellij's latest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ test-output
 .idea/dictionaries/
 .idea/codeStyles/
 .idea/.name
+.idea/*
 # Local config to handle using Java 8 vs java 11.
 .java-version
 *.tgz

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- updating gradle version to 6.7.1 as sync was falling with IntelliJ IDEA 2021.1.2 (Community Edition)Build #IC-211.7442.40, built on June 1, 2021 on mac
