### PR TITLE
Default values for Entity and Config service timeouts in application.…

### DIFF
--- a/hypertrace-service/src/main/resources/configs/hypertrace-graphql-service/default-cluster/application.conf
+++ b/hypertrace-service/src/main/resources/configs/hypertrace-graphql-service/default-cluster/application.conf
@@ -5,6 +5,8 @@ attribute.service = {
   host = ${?ATTRIBUTE_SERVICE_HOST_CONFIG}
   port = 9001
   port = ${?ATTRIBUTE_SERVICE_PORT_CONFIG}
+  timeout = 10s
+  timeout = ${?ATTRIBUTE_SERVICE_TIMEOUT}
 }
 
 gateway.service = {
@@ -20,7 +22,8 @@ entity.service = {
   host = localhost
   host = ${?ENTITY_SERVICE_HOST_CONFIG}
   port = 9001
-  port = ${?ENTITY_SERVICE_PORT_CONFIG}
+  timeout = 10s
+  timeout = ${?ENTITY_SERVICE_TIMEOUT}
 }
 
 config.service = {
@@ -28,4 +31,6 @@ config.service = {
   host = ${?CONFIG_SERVICE_HOST_CONFIG}
   port = 9001
   port = ${?CONFIG_SERVICE_PORT_CONFIG}
+  timeout = 10s
+  timeout = ${?CONFIG_SERVICE_TIMEOUT}
 }


### PR DESCRIPTION
…conf

## Description
Refer: PRs [here](https://github.com/hypertrace/hypertrace-core-graphql/pull/71) and [here](https://github.com/hypertrace/hypertrace-graphql/pull/92). This PR adds default configs in application.conf.


### Testing
Changes were tested locally with both configured timeout and default timeout.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

